### PR TITLE
fish: guard Homebrew-only env behind `command -v brew`

### DIFF
--- a/shared/.config/fish/config.fish
+++ b/shared/.config/fish/config.fish
@@ -79,14 +79,18 @@ if status is-interactive
     fish_add_path $HOME/.cargo/bin                     # cargo
     source $HOME/.local/bin/env.fish                   # add .local/bin to PATH
     set -gx EDITOR 'nvim'                              # set nvim as editor
-    fish_add_path /opt/homebrew/opt/postgresql@16/bin  # add postgresql binaries to PATH
     fish_add_path $HOME/.emacs.d/bin                   # add emacs binary to PATH
 
-    # configure openssl for compilers
-    set -x LDFLAGS "-L$(brew --prefix openssl@3)/lib $LDFLAGS"
-    set -x CPPFLAGS "-I$(brew --prefix openssl@3)/include $CPPFLAGS"
-    set -x PKG_CONFIG_PATH "$(brew --prefix openssl@3)/lib/pkgconfig $PKG_CONFIG_PATH"
-    set -x LIBRARY_PATH "$(brew --prefix)/lib:$LIBRARY_PATH"
+    # macOS / Homebrew only — skipped on Linux, where `brew` is absent
+    if command -v brew >/dev/null
+        fish_add_path /opt/homebrew/opt/postgresql@16/bin  # add postgresql binaries to PATH
+
+        # configure openssl for compilers
+        set -x LDFLAGS "-L$(brew --prefix openssl@3)/lib $LDFLAGS"
+        set -x CPPFLAGS "-I$(brew --prefix openssl@3)/include $CPPFLAGS"
+        set -x PKG_CONFIG_PATH "$(brew --prefix openssl@3)/lib/pkgconfig $PKG_CONFIG_PATH"
+        set -x LIBRARY_PATH "$(brew --prefix)/lib:$LIBRARY_PATH"
+    end
 end
 
 # Added by OrbStack: command-line tools and integration


### PR DESCRIPTION
## Problem

`fish` is a shared config, but `shared/.config/fish/config.fish` had macOS/Homebrew-specific lines that error on Linux every startup:

```
fish: Unknown command: brew
    set -x LDFLAGS "-L$(brew --prefix openssl@3)/lib $LDFLAGS"
```

## Fix

Wrap the Homebrew postgresql PATH and the openssl compiler env vars in `if command -v brew >/dev/null … end`. Runs unchanged on macOS; cleanly skipped on Linux (Arch/Omarchy provides openssl system-wide, so no Linux equivalent is needed).

Verified: a fresh `fish -l` now starts with no errors on this Omarchy box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)